### PR TITLE
Transaction ID Bugfix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group 'org.twostack'
-version '1.2.0-SNAPSHOT'
+version '1.3.0'
 
 repositories {
     mavenCentral()

--- a/src/main/java/org/twostack/bitcoin4j/PrivateKey.java
+++ b/src/main/java/org/twostack/bitcoin4j/PrivateKey.java
@@ -44,6 +44,8 @@ public class PrivateKey {
         return sig.encodeToDER();
     }
 
+
+    //FIXME: We can use DumpedPrivateKey to replace the internals here
     public static PrivateKey fromWIF(String wif) throws InvalidKeyException {
 
         boolean isCompressed = false;
@@ -80,6 +82,10 @@ public class PrivateKey {
         ECKey key = ECKey.fromPrivate(d);
 
         return new PrivateKey(key, isCompressed, networkType);
+    }
+
+    public String toWif(NetworkType networkType){
+        return this.key.getPrivateKeyAsWiF(networkType);
     }
 
 

--- a/src/main/java/org/twostack/bitcoin4j/transaction/Transaction.java
+++ b/src/main/java/org/twostack/bitcoin4j/transaction/Transaction.java
@@ -259,7 +259,7 @@ public class Transaction {
             return new byte[]{};
         }
 
-        return txHash.array();
+        return Utils.reverseBytes(txHash.array());
     }
 
     public void addOutput(TransactionOutput output) {


### PR DESCRIPTION
- This is a rather serious one. When serializing transactions the
  wrong endianness is generated, resulting in a revered TXID not
  recognised by the network. Transactions won't broadcast like this.