### PR TITLE
Minor fixes

### DIFF
--- a/src/main/java/org/twostack/bitcoin4j/script/ScriptFlags.java
+++ b/src/main/java/org/twostack/bitcoin4j/script/ScriptFlags.java
@@ -113,39 +113,39 @@ package org.twostack.bitcoin4j.script;
 /// ## SEQUENCE_LOCKTIME_MASK
 /// If CTxIn::nSequence encodes a relative lock-time, this mask is applied to
 /// extract that lock-time from the sequence field.
-class ScriptFlags {
+public class ScriptFlags {
 
     /// bitcoind commit: b5d1b1092998bc95313856d535c632ea5a8f9104
-    static final int SCRIPT_VERIFY_NONE = 0;
+    public static final int SCRIPT_VERIFY_NONE = 0;
 
     /// Evaluate P2SH subscripts (softfork safe, BIP16).
-    static final int SCRIPT_VERIFY_P2SH = (1 << 0);
+    public static final int SCRIPT_VERIFY_P2SH = (1 << 0);
 
 
     /// Passing a non-strict-DER signature or one with undefined hashtype to a checksig operation causes script failure.
     /// Passing a pubkey that is not (0x04 + 64 bytes) or (0x02 or 0x03 + 32 bytes) to checksig causes that pubkey to be
     /// skipped (not softfork safe: this flag can widen the validity of OP_CHECKSIG OP_NOT).
-    static final int SCRIPT_VERIFY_STRICTENC = (1 << 1);
+    public static final int SCRIPT_VERIFY_STRICTENC = (1 << 1);
 
     /// Passing a non-strict-DER signature to a checksig operation causes script failure (softfork safe, BIP62 rule 1)
-    static final int SCRIPT_VERIFY_DERSIG = (1 << 2);
+    public static final int SCRIPT_VERIFY_DERSIG = (1 << 2);
 
     /// Pa non-strict-DER signature or one with S > order/2 to a checksig operation causes script failure
     /// (softfork safe, BIP62 rule 5).
-    static final int SCRIPT_VERIFY_LOW_S = (1 << 3);
+    public static final int SCRIPT_VERIFY_LOW_S = (1 << 3);
 
     /// verify dummy stack item consumed by CHECKMULTISIG is of zero-length (softfork safe, BIP62 rule 7).
-    static final int SCRIPT_VERIFY_NULLDUMMY = (1 << 4);
+    public static final int SCRIPT_VERIFY_NULLDUMMY = (1 << 4);
 
     /// Using a non-push operator in the scriptSig causes script failure (softfork safe, BIP62 rule 2).
-    static final int SCRIPT_VERIFY_SIGPUSHONLY = (1 << 5);
+    public static final int SCRIPT_VERIFY_SIGPUSHONLY = (1 << 5);
 
     /// Require minimal encodings for all push operations (OP_0... OP_16, OP_1NEGATE where possible, direct
     /// pushes up to 75 bytes, OP_PUSHDATA up to 255 bytes, OP_PUSHDATA2 for anything larger). Evaluating
     /// any other push causes the script to fail (BIP62 rule 3).
     /// In addition, whenever a stack element is interpreted as a number, it must be of minimal length (BIP62 rule 4).
     /// (softfork safe)
-    static final int SCRIPT_VERIFY_MINIMALDATA = (1 << 6);
+    public static final int SCRIPT_VERIFY_MINIMALDATA = (1 << 6);
 
     /// Discourage use of NOPs reserved for upgrades (NOP1-10)
     ///
@@ -155,7 +155,7 @@ class ScriptFlags {
     /// discouraged NOPs fails the script. This verification flag will never be
     /// a mandatory flag applied to scripts in a block. NOPs that are not
     /// executed, e.g.  within an unexecuted IF ENDIF block, are *not* rejected.
-    static final int SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_NOPS = (1 << 7);
+    public static final int SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_NOPS = (1 << 7);
 
     /// Require that only a single stack element remains after evaluation. This
     /// changes the success criterion from "At least one stack element must
@@ -164,62 +164,62 @@ class ScriptFlags {
     /// be true".
     /// (softfork safe, BIP62 rule 6)
     /// Note: CLEANSTACK should never be used without P2SH or WITNESS.
-    static final int SCRIPT_VERIFY_CLEANSTACK = (1 << 8);
+    public static final int SCRIPT_VERIFY_CLEANSTACK = (1 << 8);
 
     /// Cstatic final LTV See BIP65 for details.
-    static final int SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY = (1 << 9);
+    public static final int SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY = (1 << 9);
 
     /// support CHECKSEQUENCEVERIFY opcode
     ///
     /// See BIP112 for details
-    static final int SCRIPT_VERIFY_CHECKSEQUENCEVERIFY = (1 << 10);
+    public static final int SCRIPT_VERIFY_CHECKSEQUENCEVERIFY = (1 << 10);
 
     /// Segwit script only: Require the argument of OP_IF/NOTIF to be exactly
     /// 0x01 or empty vector
     ///
-    static final int SCRIPT_VERIFY_MINIMALIF = (1 << 13);
+    public static final int SCRIPT_VERIFY_MINIMALIF = (1 << 13);
 
     /// Signature(s) must be empty vector if an CHECK(MULTI)SIG operation failed
     ///
-    static final int SCRIPT_VERIFY_NULLFAIL = (1 << 14);
+    public static final int SCRIPT_VERIFY_NULLFAIL = (1 << 14);
 
     /// Public keys in scripts must be compressed
-    static final int SCRIPT_VERIFY_COMPRESSED_PUBKEYTYPE = (1 << 15);
+    public static final int SCRIPT_VERIFY_COMPRESSED_PUBKEYTYPE = (1 << 15);
 
     /// Do we accept signature using SIGHASH_FORKID
     ///
-    static final int SCRIPT_ENABLE_SIGHASH_FORKID = (1 << 16);
+    public static final int SCRIPT_ENABLE_SIGHASH_FORKID = (1 << 16);
 
     /// Do we accept activate replay protection using a different fork id.
     ///
-    static final int SCRIPT_ENABLE_REPLAY_PROTECTION = (1 << 17);
+    public static final int SCRIPT_ENABLE_REPLAY_PROTECTION = (1 << 17);
 
     /// Enable new opcodes.
     ///
-    static final int SCRIPT_ENABLE_MONOLITH_OPCODES = (1 << 18);
+    public static final int SCRIPT_ENABLE_MONOLITH_OPCODES = (1 << 18);
 
     /// Are the Magnetic upgrade opcodes enabled?
     ///
-    static final int SCRIPT_ENABLE_MAGNETIC_OPCODES = (1 << 19);
+    public static final int SCRIPT_ENABLE_MAGNETIC_OPCODES = (1 << 19);
 
     /// *Below flags apply in the context of BIP 68*
     ///
     /// If this flag set, CTxIn::nSequence is NOT interpreted as a relative lock-time.
 
-    static final int SEQUENCE_LOCKTIME_DISABLE_FLAG = (1 << 31);
+    public static final int SEQUENCE_LOCKTIME_DISABLE_FLAG = (1 << 31);
 
 
     /// If CTxIn::nSequence encodes a relative lock-time and this flag is set,
     /// the relative lock-time has units of 512 seconds, otherwise it specifies
     /// blocks with a granularity of 1.
 
-    static final int SEQUENCE_LOCKTIME_TYPE_FLAG = (1 << 22);
+    public static final int SEQUENCE_LOCKTIME_TYPE_FLAG = (1 << 22);
 
     ///
     ///  If CTxIn::nSequence encodes a relative lock-time, this mask is applied to
     ///  extract that lock-time from the sequence field.
     ///
-    static final int SEQUENCE_LOCKTIME_MASK = 0x0000ffff;
+    public static final int SEQUENCE_LOCKTIME_MASK = 0x0000ffff;
 
 
 }

--- a/src/main/java/org/twostack/bitcoin4j/transaction/DefaultUnlockBuilder.java
+++ b/src/main/java/org/twostack/bitcoin4j/transaction/DefaultUnlockBuilder.java
@@ -25,11 +25,11 @@ public class DefaultUnlockBuilder extends UnlockingScriptBuilder {
 
     List<TransactionSignature> signatures = new ArrayList<>();
 
-    DefaultUnlockBuilder(){
+    public DefaultUnlockBuilder(){
         super();
     }
 
-    DefaultUnlockBuilder(Script script){
+    public DefaultUnlockBuilder(Script script){
         super(script);
     }
 

--- a/src/main/java/org/twostack/bitcoin4j/transaction/Transaction.java
+++ b/src/main/java/org/twostack/bitcoin4j/transaction/Transaction.java
@@ -30,7 +30,6 @@ import java.util.*;
 
 public class Transaction {
 
-
     private long version = 1;
     private long nLockTime = 0;
     private ArrayList<TransactionInput> inputs = new ArrayList<>();
@@ -40,7 +39,7 @@ public class Transaction {
     public static final long NLOCKTIME_MAX_VALUE = 4294967295L;
 
     public static final long MAX_COINS = 21000000;
-    /// max amount of satoshis in circulation
+    /// max amount of bitcoins in circulation
 
     private static final int SMALLEST_UNIT_EXPONENT = 8;
     private static final long COIN_VALUE = LongMath.pow(10, SMALLEST_UNIT_EXPONENT);
@@ -247,11 +246,11 @@ public class Transaction {
     }
 
     public String getTransactionId(){
-        if (txHash == null){
+        byte[] idBytes = getTransactionIdBytes();
+        if (idBytes.length == 0) {
             return "";
         }
-
-        return Utils.HEX.encode(txHash.array());
+        return Utils.HEX.encode(idBytes);
     }
 
     public byte[] getTransactionIdBytes(){

--- a/src/main/java/org/twostack/bitcoin4j/transaction/TransactionBuilder.java
+++ b/src/main/java/org/twostack/bitcoin4j/transaction/TransactionBuilder.java
@@ -31,7 +31,7 @@ public class TransactionBuilder {
     private List<TransactionInput> inputs = new ArrayList<>();
     private List<TransactionOutput> outputs = new ArrayList<>();
 
-    //Map the transactionIds we're spending from, to the corresponding UXTO amount in the output
+    //Map the transactionIds we're spending from, to the corresponding UTXO amount in the output
     private Map<String, BigInteger> spendingMap = new HashMap();
 
     private LockingScriptBuilder changeScriptBuilder;
@@ -42,7 +42,7 @@ public class TransactionBuilder {
 
     static final BigInteger DUST_AMOUNT = BigInteger.valueOf(256);
 
-    /// Margin of error to allow fees in the vecinity of the expected value but doesn't allow a big difference
+    /// Margin of error to allow fees in the vicinity of the expected value but doesn't allow a big difference
     private static final BigInteger FEE_SECURITY_MARGIN = BigInteger.valueOf(150);
 
     private long feePerKb = DEFAULT_FEE_PER_KB;
@@ -62,7 +62,7 @@ public class TransactionBuilder {
     private long nLockTime = 0;
 
     /*
-        utxoMap is expect to have :
+        utxoMap is expected to have :
 
         {
             "transactionId" : [String],

--- a/src/main/java/org/twostack/bitcoin4j/transaction/TransactionInput.java
+++ b/src/main/java/org/twostack/bitcoin4j/transaction/TransactionInput.java
@@ -31,7 +31,7 @@ public class TransactionInput {
         want to indicate that the transaction's [Transaction.nLockTime] should be ignored.
         This is a 64-bit value, in range 0 to (2^64) - 1
      */
-    static long MAX_SEQ_NUMBER =  0xFFFFFFFFL;
+    public static long MAX_SEQ_NUMBER =  0xFFFFFFFFL;
 
     private long _sequenceNumber;
 

--- a/src/main/java/org/twostack/bitcoin4j/transaction/TransactionOutput.java
+++ b/src/main/java/org/twostack/bitcoin4j/transaction/TransactionOutput.java
@@ -43,7 +43,7 @@ public class TransactionOutput {
         return new TransactionOutput(satoshis, script);
     }
 
-    TransactionOutput(BigInteger satoshis, LockingScriptBuilder builder){
+    public TransactionOutput(BigInteger satoshis, LockingScriptBuilder builder){
         this.satoshis = satoshis;
         this._lockingScriptBuilder = builder;
     }

--- a/src/main/java/org/twostack/bitcoin4j/transaction/TransactionSigner.java
+++ b/src/main/java/org/twostack/bitcoin4j/transaction/TransactionSigner.java
@@ -47,7 +47,7 @@ public class TransactionSigner {
         byte[] hash = sigHash.createHash(unsignedTxn, sigHashType, inputIndex, subscript, utxo.getAmount());
 
         //FIXME: Revisit this issue surrounding the need to sign a reversed copy of the hash.
-        ///      Right now I've factored this out of signature.dart because 'coupling' & 'seperation of concerns'.
+        ///      Right now I've factored this out of signature.dart because 'coupling' & 'separation of concerns'.
         //       var reversedHash = Utils.HEX.encode(HEX.decode(hash).reversed.toList());
 
         // generate a signature for the input

--- a/src/test/java/org/twostack/bitcoin4j/transaction/TransactionTest.java
+++ b/src/test/java/org/twostack/bitcoin4j/transaction/TransactionTest.java
@@ -68,6 +68,12 @@ public class TransactionTest {
     }
 
     @Test
+    public void TestTransactionIdMatchesTransactionHash() {
+        Transaction transaction = Transaction.fromHex(tx1hex);
+        assertEquals(tx1id, transaction.getTransactionId());
+    }
+
+    @Test
     public void can_create_and_sign_transaction() throws InvalidKeyException, TransactionException, IOException, SigHashException {
 
         PrivateKey privateKey = PrivateKey.fromWIF("cVVvUsNHhbrgd7aW3gnuGo2qJM45LhHhTCVXrDSJDDcNGE6qmyCs");


### PR DESCRIPTION
* Ensure and test that Transaction ID matches its hash. This appears to have been fixed in `Transaction.getTransactionIdBytes()` but not `Transaction.getTransactionId()`
* Make some classes and constants public to be usable from the read-only library
* Minor typo fixes in comments