### PR TITLE
Modular Arithmetic and Big Integers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group 'org.twostack'
-version '1.4.2-SNAPSHOT'
+version '1.5.0-SNAPSHOT'
 
 repositories {
     mavenCentral()

--- a/src/test/java/org/twostack/bitcoin4j/script/ScriptTest.java
+++ b/src/test/java/org/twostack/bitcoin4j/script/ScriptTest.java
@@ -257,50 +257,6 @@ public class ScriptTest {
 
 
 
-//    @Test
-//    public void dataDrivenValidScripts() throws Exception {
-//        JsonNode json = new ObjectMapper().readTree(new InputStreamReader(getClass().getResourceAsStream(
-//                "script_valid.json"), Charsets.UTF_8));
-//        for (JsonNode test : json) {
-//            Script scriptSig = parseScriptString(test.get(0).asText());
-//            Script scriptPubKey = parseScriptString(test.get(1).asText());
-//            Set<VerifyFlag> verifyFlags = parseVerifyFlags(test.get(2).asText());
-//            try {
-//
-//
-//                Interpreter interp = new Interpreter();
-//                interp.correctlySpends( scriptSig, scriptPubKey, new Transaction(), 0 , verifyFlags);
-//
-//            } catch (ScriptException e) {
-//                System.err.println(test);
-//                System.err.flush();
-//                throw e;
-//            }
-//        }
-//    }
-//
-//
-//    @Test
-//    public void dataDrivenInvalidScripts() throws Exception {
-//        JsonNode json = new ObjectMapper().readTree(new InputStreamReader(getClass().getResourceAsStream(
-//                "script_invalid.json"), Charsets.UTF_8));
-//        for (JsonNode test : json) {
-//            try {
-//                Script scriptSig = parseScriptString(test.get(0).asText());
-//                Script scriptPubKey = parseScriptString(test.get(1).asText());
-//                Set<VerifyFlag> verifyFlags = parseVerifyFlags(test.get(2).asText());
-//
-//                Interpreter interp = new Interpreter();
-//                interp.correctlySpends( scriptSig, scriptPubKey, new Transaction(), 0 , verifyFlags);
-//
-//                System.err.println(test);
-//                System.err.flush();
-//                fail();
-//            } catch (VerificationException e) {
-//                // Expected.
-//            }
-//        }
-//    }
 
     @Test
     public void parseKnownAsm() throws IOException {


### PR DESCRIPTION
- Java BigInteger does not support modular arithmetic on negative numbers
  so we use BigDecimal as temporary substitute
- Expanded the Genesis Upgrade support to cover BigIntegers in general