### PR TITLE
Javadoc fixes

### DIFF
--- a/src/main/java/org/twostack/bitcoin4j/Monetary.java
+++ b/src/main/java/org/twostack/bitcoin4j/Monetary.java
@@ -24,13 +24,13 @@ import java.io.Serializable;
 public interface Monetary extends Serializable {
 
     /**
-     * Returns the absolute value of exponent of the value of a "smallest unit" in scientific notation. For Bitcoin, a
+     * @return the absolute value of exponent of the value of a "smallest unit" in scientific notation. For Bitcoin, a
      * satoshi is worth 1E-8 so this would be 8.
      */
     int smallestUnitExponent();
 
     /**
-     * Returns the number of "smallest units" of this monetary value. For Bitcoin, this would be the number of satoshis.
+     * @return the number of "smallest units" of this monetary value. For Bitcoin, this would be the number of satoshis.
      */
     long getValue();
 

--- a/src/main/java/org/twostack/bitcoin4j/address/Base58.java
+++ b/src/main/java/org/twostack/bitcoin4j/address/Base58.java
@@ -169,7 +169,7 @@ public class Base58 {
      *
      * @param input the base58-encoded string to decode (which should include the checksum)
      * @throws AddressFormatException if the input is not base 58 or the checksum does not validate.
-     * @return
+     * @return the original data bytes as a byte array
      */
     public static byte[] decodeChecked(String input) throws AddressFormatException {
         byte[] decoded  = decode(input);

--- a/src/main/java/org/twostack/bitcoin4j/address/LegacyAddress.java
+++ b/src/main/java/org/twostack/bitcoin4j/address/LegacyAddress.java
@@ -132,6 +132,8 @@ public class LegacyAddress extends Address {
      *             if the given base58 doesn't parse or the checksum is invalid
      * @throws AddressFormatException.WrongNetwork
      *             if the given address is valid but for a different chain (eg testnet vs mainnet)
+     *
+     * @return a LegacyAddress instance conforming to the provided {@link NetworkType}
      */
     public static LegacyAddress fromBase58(@Nullable NetworkType networkType, String base58)
             throws AddressFormatException {
@@ -205,6 +207,8 @@ public class LegacyAddress extends Address {
      * Given an address, examines the version byte and attempts to find a matching NetworkParameters. If you aren't sure
      * which network the address is intended for (eg, it was provided by a user), you can use this to decide if it is
      * compatible with the current wallet.
+     *
+     * @param address the base58-encoded bitcoin address from which to construct the {@link NetworkAddressType}
      *
      * @return network the address is valid for
      * @throws AddressFormatException if the given base58 doesn't parse or the checksum is invalid


### PR DESCRIPTION
- Fixed javadocs for Monetary
- Fixed javadocs for base58 encoder
- Fixed javadocs for legacy addresses