### PR TITLE
Locking script & tx spending fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group 'org.twostack'
-version '1.5.2'
+version '1.5.5'
 
 repositories {
     mavenCentral()

--- a/src/main/java/org/twostack/bitcoin4j/transaction/P2PKHDataLockBuilder.java
+++ b/src/main/java/org/twostack/bitcoin4j/transaction/P2PKHDataLockBuilder.java
@@ -64,8 +64,8 @@ public class P2PKHDataLockBuilder extends LockingScriptBuilder{
 
             List<ScriptChunk> chunkList = script.getChunks();
 
-            if (chunkList.size() != 8 && chunkList.size() != 7 ){
-                throw new ScriptException(ScriptError.SCRIPT_ERR_UNKNOWN_ERROR,"Wrong number of data elements for locking script");
+            if (!chunkList.get(0).isPushData() && chunkList.get(1).opcode != OP_DROP){
+                throw new ScriptException(ScriptError.SCRIPT_ERR_UNKNOWN_ERROR,"Script must start with PUSHDATA & DROP instruction.");
             }
 
             int chunkListOffset = 0;

--- a/src/main/java/org/twostack/bitcoin4j/transaction/TransactionBuilder.java
+++ b/src/main/java/org/twostack/bitcoin4j/transaction/TransactionBuilder.java
@@ -17,6 +17,7 @@
 package org.twostack.bitcoin4j.transaction;
 
 import org.twostack.bitcoin4j.Address;
+import org.twostack.bitcoin4j.Utils;
 import org.twostack.bitcoin4j.exception.TransactionException;
 import org.twostack.bitcoin4j.script.Script;
 
@@ -101,7 +102,7 @@ public class TransactionBuilder {
     public TransactionBuilder spendFromTransaction(Transaction txn, int outputIndex, long sequenceNumber, UnlockingScriptBuilder unlocker){
 
         TransactionInput input = new TransactionInput(
-                txn.getTransactionIdBytes(),
+                Utils.reverseBytes(txn.getTransactionIdBytes()),
                 outputIndex,
                 sequenceNumber,
                 unlocker
@@ -399,7 +400,7 @@ public class TransactionBuilder {
         return changeOutput;
     }
 
-    private BigInteger calculateChange(){
+    public BigInteger calculateChange(){
         BigInteger inputAmount = calcInputTotals();
         BigInteger outputAmount = calcRecipientTotals();
         BigInteger unspent = inputAmount.subtract(outputAmount);
@@ -407,7 +408,7 @@ public class TransactionBuilder {
         return unspent.subtract(getFee()); //sub
     }
 
-    private BigInteger getFee(){
+    public BigInteger getFee(){
 
         if (transactionFee != null){
             return transactionFee;
@@ -437,7 +438,7 @@ public class TransactionBuilder {
         return fee;
     }
 
-    private long estimateSize(){
+    public long estimateSize(){
         int result = MAXIMUM_EXTRA_SIZE;
 
         for (TransactionInput input: inputs){
@@ -451,7 +452,7 @@ public class TransactionBuilder {
         return result;
     }
 
-    private BigInteger calcInputTotals(){
+    public BigInteger calcInputTotals(){
 
         BigInteger amount = BigInteger.ZERO;
         for (BigInteger value : spendingMap.values()) {
@@ -461,7 +462,7 @@ public class TransactionBuilder {
         return amount;
     }
 
-    private BigInteger calcRecipientTotals() {
+    public BigInteger calcRecipientTotals() {
 
         BigInteger amount = BigInteger.ZERO;
         for (TransactionOutput output: outputs) {

--- a/src/main/java/org/twostack/bitcoin4j/transaction/TransactionOutpoint.java
+++ b/src/main/java/org/twostack/bitcoin4j/transaction/TransactionOutpoint.java
@@ -20,6 +20,7 @@ package org.twostack.bitcoin4j.transaction;
 import org.twostack.bitcoin4j.script.Script;
 
 import java.math.BigInteger;
+import java.util.Objects;
 
 /**
  * This is more traditionally referred to as a UTXO. The Transaction Outpoint is a convenience
@@ -65,5 +66,18 @@ public class TransactionOutpoint {
 
     public void setLockingScript(Script lockingScript) {
         this.lockingScript = lockingScript;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TransactionOutpoint outpoint = (TransactionOutpoint) o;
+        return transactionId.equals(outpoint.transactionId) && outputIndex.equals(outpoint.outputIndex) && satoshis.equals(outpoint.satoshis) && Objects.equals(lockingScript, outpoint.lockingScript);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(transactionId, outputIndex, satoshis, lockingScript);
     }
 }


### PR DESCRIPTION
- The spendFromTransaction() fundion in TransactionBuilder was using the
  incorrect endian encoding the for the transactionID. Fixed.
- The P2PKHDataLockBuilder had a broken means for validating
  the script template. fixed.
- Added hashcode and equals to TransactionOutpoint so it can used in
  collections