### PR TITLE
Script size fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+#Release 1.6.6
+### Bug Fixes and small Feature improvement
+
+Fixed script-size bug
+    - Script-size limit of 10k bytes should only be done for P2SH scripts with STRICTENC flag.
+
+Bug fix - reversed hashes
+    - placed internal hashes in correct byte order
+
+Blocks & Utilities
+    - Added ability to construct Transactions from Streams
+    - Added streaming constructor to VarInt
+    - Added functionality to Block. It used to be mostly a stub.
+    - Minor documentation fixes
+
+Additional utilities for number manipulation
+
+Bugfix for fee calculations
+    - Fee calculation when spending multiple utxos from same transaction
+      was broken. 
+
 #Release 1.6.4
 ### Second BugFix for Signature Generation
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group 'org.twostack'
-version '1.6.5'
+version '1.6.6'
 
 repositories {
     mavenCentral()

--- a/src/main/java/org/twostack/bitcoin4j/script/Interpreter.java
+++ b/src/main/java/org/twostack/bitcoin4j/script/Interpreter.java
@@ -1108,8 +1108,11 @@ public class Interpreter {
         } catch (ProtocolException | IOException e) {
             throw new RuntimeException(e);   // Should not happen unless we were given a totally broken transaction.
         }
-        if (scriptSig.getProgram().length > 10000 || scriptPubKey.getProgram().length > 10000)
-            throw new ScriptException(ScriptError.SCRIPT_ERR_SCRIPT_SIZE, "Script larger than 10,000 bytes");
+
+        if (verifyFlags.contains(VerifyFlag.P2SH) && verifyFlags.contains(VerifyFlag.STRICTENC)) {
+            if (scriptSig.getProgram().length > 10000 || scriptPubKey.getProgram().length > 10000)
+                throw new ScriptException(ScriptError.SCRIPT_ERR_SCRIPT_SIZE, "Script larger than 10,000 bytes");
+        }
 
         LinkedList<byte[]> stack = new LinkedList<byte[]>();
         LinkedList<byte[]> p2shStack = null;


### PR DESCRIPTION
 Script-size limit of 10k bytes should only be done for P2SH scripts with STRICTENC flag.